### PR TITLE
Broaden reg-ex to match preferred resolver

### DIFF
--- a/rawItem.rb
+++ b/rawItem.rb
@@ -103,7 +103,7 @@ end
 def normalizeIdentifier(str)
   str or return ''
   tmp = str.downcase.strip
-  tmp = tmp.sub(/^https?:\/\/dx.doi.org\//, '').sub(/^(doi(\.org)?|pmid|pmcid):/, '').sub(/\.+$/, '')
+  tmp = tmp.sub(/^https?:\/\/(dx\.)?doi.org\//, '').sub(/^(doi(\.org)?|pmid|pmcid):/, '').sub(/\.+$/, '')
   tmp = tmp.sub(/^\[(.*)\]$/, '\1').sub(/^"(.*)"$/, '\1').sub(/^\[(.*)\]$/, '\1').sub(/^"(.*)"$/, '\1')
   return tmp
 end


### PR DESCRIPTION
Hello :-)

Because [the DOI foundation started recommending this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8), I guessed that it would be useful to treat its non-`dx.`-URLs in the same way here.

Cheers!